### PR TITLE
Add Builtin Roles to AutomatedLab PSU

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+    "files.autoSave": "off",
+    "editor.autoClosingQuotes": "never",
+    "editor.formatOnSave": false,
+    "editor.formatOnType": false,
+    "editor.formatOnPaste": false,
+    "files.trimTrailingWhitespace": false,
+    "files.insertFinalNewline": false,
+    "files.trimFinalNewlines": true,
+    "editor.trimAutoWhitespace": false,
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4,
+    "editor.detectIndentation": false,
+    "[powershell]": {
+        "editor.formatOnSave": false,
+        "editor.formatOnType": false,
+        "editor.formatOnPaste": false,
+        "files.trimTrailingWhitespace": false,
+        "files.insertFinalNewline": false,
+        "files.trimFinalNewlines": true,
+        "editor.trimAutoWhitespace": false,
+    }
+}

--- a/PowerShellUniversal.Apps.AutomatedLab/PowerShellUniversal.Apps.AutomatedLab.psm1
+++ b/PowerShellUniversal.Apps.AutomatedLab/PowerShellUniversal.Apps.AutomatedLab.psm1
@@ -291,8 +291,13 @@ New-LabDefinition -Name '$($LabData.LabName)' -DefaultVirtualizationEngine Hyper
 
         # Add VMs
         foreach ($vm in $LabData.VMs) {
-            $script += "Add-LabMachineDefinition -Name '$($vm.Name)' -OperatingSystem '$($vm.OS)' -Memory $($vm.RAM)GB -Processors $($vm.CPU)"
-        
+            if($vm.BuiltInRoles -and $vm.BuiltInRoles.Count -gt 0) {
+                $roles = ($vm.BuiltInRoles | ForEach-Object { "'$_'" }) -join ','
+                $script += "Add-LabMachineDefinition -Name '$($vm.Name)' -OperatingSystem '$($vm.OS)' -Memory $($vm.RAM)GB -Processors $($vm.CPU) -Roles @($roles)"
+            } else {
+                $script += "Add-LabMachineDefinition -Name '$($vm.Name)' -OperatingSystem '$($vm.OS)' -Memory $($vm.RAM)GB -Processors $($vm.CPU)"
+            }
+
             if ($vm.NetworkAdapters -and $vm.NetworkAdapters.Count -gt 0) {
                 $adapters = $vm.NetworkAdapters | ForEach-Object {
                     $adapterDef = "New-LabNetworkAdapterDefinition -VirtualSwitch '$($_.VirtualSwitch)'"


### PR DESCRIPTION
This pull request adds support for assigning built-in roles to virtual machines (VMs) in the lab creation wizard, improving both the user interface and the underlying script generation. The main changes introduce a new UI card for built-in roles, ensure built-in roles are tracked and displayed for each VM, and update the script logic to include these roles when provisioning VMs.

**User Interface Enhancements:**

* Added a "Built-In Roles" card to the VM creation wizard, allowing users to select, add, and remove built-in roles for each VM. This includes dynamic role selection, feedback messages, and a table to display assigned roles.
* Updated the VM summary table to display assigned built-in roles alongside custom roles, showing both the count and names of roles per VM.

**State Management Improvements:**

* Ensured that built-in roles are tracked in the session state for each VM, properly initialized and reset when creating or clearing a VM.

**Script Generation Updates:**

* Modified the VM provisioning script logic to include built-in roles when generating the `Add-LabMachineDefinition` command, so assigned roles are reflected in the deployment script.

**Configuration Updates:**

* Added a `.vscode/settings.json` file with workspace-specific editor and formatting preferences to standardize development environment behavior. Please add your formatting settings. I have different formatting settings than you so I had to do a lot of work to honor your formatting rules.

Fixes #2 